### PR TITLE
[bugfix] Fix ldap import

### DIFF
--- a/python/ExtractBitlockerKeys.py
+++ b/python/ExtractBitlockerKeys.py
@@ -6,7 +6,7 @@
 
 
 import argparse
-from sectools.windows.ldap import raw_ldap_query, init_ldap_session
+from sectools.windows.ldap.ldap import raw_ldap_query, init_ldap_session
 from sectools.windows.crypto import nt_hash, parse_lm_nt_hashes
 import os
 import sys
@@ -205,11 +205,11 @@ if __name__ == '__main__':
 
     if options.auth_key is not None:
         options.use_kerberos = True
-    
+
     if options.use_kerberos is True and options.kdcHost is None:
         print("[!] Specify KDC's Hostname of FQDN using the argument --kdcHost")
         exit()
-    
+
     if not options.quiet:
         print("[>] Extracting BitLocker recovery keys of all computers ...")
 


### PR DESCRIPTION
Hi,

There is an issue when importing the sectools ldap module, which causes the tool to crash on launch.

```bash
git -C /opt/tools/ clone --depth 1 https://github.com/p0dalirius/ExtractBitlockerKeys
python3 -m venv --system-site-packages ./venv
source ./venv/bin/activate
pip install -r requirements.txt
/opt/tools/ExtractBitlockerKeys/venv/bin/python3 /opt/tools/ExtractBitlockerKeys/python/ExtractBitlockerKeys.py --help
```

```bash
Traceback (most recent call last):
  File "/opt/tools/ExtractBitlockerKeys/python/ExtractBitlockerKeys.py", line 9, in <module>
    from sectools.windows.ldap import raw_ldap_query, init_ldap_session
ImportError: cannot import name 'raw_ldap_query' from 'sectools.windows.ldap' (/opt/tools/sectools/sectools/windows/ldap/__init__.py)
```

The problem is due to the import of the ldap module, which is a file called ldap.py in a folder called ldap : https://github.com/p0dalirius/sectools/blob/main/sectools/windows/ldap/ldap.py

---

With my fix :

```bash
git -C /opt/tools/ clone --depth 1 https://github.com/p0dalirius/ExtractBitlockerKeys
python3 -m venv --system-site-packages ./venv
source ./venv/bin/activate
pip install -r requirements.txt
/opt/tools/ExtractBitlockerKeys/venv/bin/python3 /opt/tools/ExtractBitlockerKeys/python/ExtractBitlockerKeys.py --help
```

```bash
ExtractBitlockerKeys.py v1.3 - by Remi GASCOU (Podalirius)

usage: ExtractBitlockerKeys.py [-h] [-v] [-q] [-t THREADS] [--export-xlsx EXPORT_XLSX] [--export-json EXPORT_JSON] [--export-sqlite EXPORT_SQLITE] --dc-ip ip address [--kdcHost FQDN KDC]
                               [-d DOMAIN] [-u USER] [--no-pass | -p PASSWORD | -H [LMHASH:]NTHASH | --aes-key hex key] [-k]

options:
  -h, --help            show this help message and exit
  -v, --verbose         Verbose mode. (default: False)
  -q, --quiet           Show no information at all.
  -t THREADS, --threads THREADS
                        Number of threads (default: 4).

Output files:
  --export-xlsx EXPORT_XLSX
                        Output XLSX file to store the results in.
  --export-json EXPORT_JSON
                        Output JSON file to store the results in.
  --export-sqlite EXPORT_SQLITE
                        Output SQLITE3 file to store the results in.

Authentication & connection:
  --dc-ip ip address    IP Address of the domain controller or KDC (Key Distribution Center) for Kerberos. If omitted it will use the domain part (FQDN) specified in the identity parameter
  --kdcHost FQDN KDC    FQDN of KDC for Kerberos.
  -d DOMAIN, --domain DOMAIN
                        (FQDN) domain to authenticate to
  -u USER, --user USER  user to authenticate with

Credentials:
  --no-pass             Don't ask for password (useful for -k)
  -p PASSWORD, --password PASSWORD
                        Password to authenticate with
  -H [LMHASH:]NTHASH, --hashes [LMHASH:]NTHASH
                        NT/LM hashes, format is LMhash:NThash
  --aes-key hex key     AES key to use for Kerberos Authentication (128 or 256 bits)
  -k, --kerberos        Use Kerberos authentication. Grabs credentials from .ccache file (KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use the ones
                        specified in the command line
```