### PR TITLE
[bugfix] fix dependency error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sectools>=1.4.1
+sectools>=1.5.0
 xlsxwriter


### PR DESCRIPTION
With sectools 1.4.4

<img width="1004" height="95" alt="image" src="https://github.com/user-attachments/assets/925b0c69-ab60-4e94-ae1a-be6b50402a0a" />

With sectools 1.5.0 (and https://github.com/p0dalirius/sectools/issues/14 fix)

<img width="941" height="149" alt="image" src="https://github.com/user-attachments/assets/f3ecd4f3-241c-4a92-9dce-599aa285f14f" />
